### PR TITLE
Changed to the check to validate the entire URI, not just the suffix

### DIFF
--- a/main.go
+++ b/main.go
@@ -158,7 +158,7 @@ func denyUsernsModeHost(w http.ResponseWriter, r *http.Request) {
 				logData[k] = v
 			}
 		}
-		if v, ok := v["UsernsMode"]; ok && v.(string) == "host" && strings.HasSuffix(req.RequestURI, "/containers/create") {
+		if v, ok := v["UsernsMode"]; ok && v.(string) == "host" && strings.Contains(req.RequestURI, "/containers/create") {
 			// Apparently you don't send 403 for a successful deny.
 			code = http.StatusOK
 			resp.Msg = "userns=host is not allowed"


### PR DESCRIPTION
It is possible to by pass the plugin by appending a "?" to the end of the url if using the API.

With the "?" the url is still valid (http parameters) and will be processed successfully by the docker api and the plugin will be bypassed.

Examples : Note the question mark at the end of the URL

Forbidden :

`curl -kv --data @create.req  -H 'Content-Type: application/json' -H 'Host: docker' --unix-socket /var/run/docker.sock http:/v1.40/containers/create
*   Trying /var/run/docker.sock...
* Connected to http (/var/run/docker.sock) port 80 (#0)
> POST /v1.40/containers/create HTTP/1.1
> Host: docker
> User-Agent: curl/7.47.0
> Accept: */*
> Content-Type: application/json
> Content-Length: 1531
> Expect: 100-continue
> 
< HTTP/1.1 100 Continue
* We are completely uploaded and fine
< HTTP/1.1 403 Forbidden
< Content-Type: application/json
< Date: Wed, 20 Nov 2019 07:43:40 GMT
< Content-Length: 88
< 
{"message":"authorization denied by plugin denyusernshost: userns=host is not allowed"}
* Connection #0 to host http left intact`

Bypassed :

`curl -kv --data @create.req  -H 'Content-Type: application/json' -H 'Host: docker' --unix-socket /var/run/docker.sock http:/v1.40/containers/create?
*   Trying /var/run/docker.sock...
* Connected to http (/var/run/docker.sock) port 80 (#0)
> POST /v1.40/containers/create? HTTP/1.1
> Host: docker
> User-Agent: curl/7.47.0
> Accept: */*
> Content-Type: application/json
> Content-Length: 1531
> Expect: 100-continue
> 
< HTTP/1.1 100 Continue
* We are completely uploaded and fine
< HTTP/1.1 201 Created
< Api-Version: 1.40
< Content-Type: application/json
< Docker-Experimental: false
< Ostype: linux
< Server: Docker/19.03.5 (linux)
< Date: Wed, 20 Nov 2019 07:47:13 GMT
< Content-Length: 88
< 
{"Id":"9762c951c50f1b71c38d0f59a4a5d1fe49f958e687538ad5852a2037729213a0","Warnings":[]}
* Connection #0 to host http left intact
`